### PR TITLE
Rename playout module for real-time buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ pipeline := pipeline.NewPipeline("assistant")
 // Add and link elements
 resample := elements.NewAudioResampleElement("resample")
 gemini := elements.NewGeminiElement("gemini", apiKey)
-playout := elements.NewPlayoutSinkElement("playout")
+audioPacer := elements.NewAudioPacerSinkElement("audioPacer")
 
 pipeline.Link(resample, gemini)
-pipeline.Link(gemini, playout)
+pipeline.Link(gemini, audioPacer)
 
 // Start processing
 pipeline.Start(ctx)

--- a/docs/grpc-architecture.md
+++ b/docs/grpc-architecture.md
@@ -53,7 +53,7 @@ The gRPC implementation provides a simpler, more portable alternative to WebRTC 
 │  ┌──────────────────────────────────────────────────────────┐  │
 │  │  Pipeline                                                 │  │
 │  │                                                           │  │
-│  │  AudioResampleElement → GeminiElement → PlayoutSinkElement  │
+│  │  AudioResampleElement → GeminiElement → AudioPacerSinkElement│
 │  │         ↓                    ↓                  ↓         │  │
 │  │    48kHz→16kHz          AI Processing      Audio Output   │  │
 │  └──────────────────────────────────────────────────────────┘  │
@@ -157,7 +157,7 @@ Client                          gRPC Server                    Pipeline
   │                                  │────────────────────────────>│
   │                                  │                             │
   │                                  │ Initialize Pipeline         │
-  │                                  │ (Resample→Gemini→Playout)  │
+  │                                  │ (Resample→Gemini→AudioPacer)│
   │                                  │────────────────────────────>│
   │                                  │                             │
   │ ControlMessage(CONNECTED)        │                             │
@@ -345,7 +345,7 @@ grpcServer.OnConnectionCreated(func(ctx context.Context, conn connection.RTCConn
     pipeline.AddElements([]pipeline.Element{
         elements.NewAudioResampleElement(48000, 16000, 1, 1),
         elements.NewGeminiElement(),
-        elements.NewPlayoutSinkElement(),
+        elements.NewAudioPacerSinkElement(),
     })
 
     // Register handler

--- a/docs/grpc-implementation-summary.md
+++ b/docs/grpc-implementation-summary.md
@@ -41,7 +41,7 @@
 - **文件**: [`examples/grpc-assis/server.go`](../examples/grpc-assis/server.go)
 - **功能**:
   - 启动 gRPC 服务器（端口 50051）
-  - 创建 Pipeline: `AudioResample → Gemini → Playout`
+  - 创建 Pipeline: `AudioResample → Gemini → AudioPacer`
   - 处理客户端连接和消息
   - 优雅关闭支持
 

--- a/docs/tts-design.md
+++ b/docs/tts-design.md
@@ -111,15 +111,15 @@ ttsElement := elements.NewUniversalTTSElement(openaiProvider)
 ttsElement.SetVoice("alloy")
 
 // Add other elements
-playoutElement := elements.NewPlayoutSinkElement()
+audioPacerElement := elements.NewAudioPacerSinkElement()
 
 // Link elements
-pipeline.AddElements([]Element{ttsElement, playoutElement})
-pipeline.Link(ttsElement, playoutElement)
+pipeline.AddElements([]Element{ttsElement, audioPacerElement})
+pipeline.Link(ttsElement, audioPacerElement)
 
 // Start pipeline
 ttsElement.Start(ctx)
-playoutElement.Start(ctx)
+audioPacerElement.Start(ctx)
 
 // Send text
 msg := &pipeline.PipelineMessage{

--- a/examples/gemini-assis/main.go
+++ b/examples/gemini-assis/main.go
@@ -31,7 +31,7 @@ func (c *connectionEventHandler) OnConnectionStateChange(state webrtc.PeerConnec
 
 	if state == webrtc.PeerConnectionStateConnected {
 
-		playoutSinkElement := elements.NewPlayoutSinkElement()
+		audioPacerSinkElement := elements.NewAudioPacerSinkElement()
 		geminiElement := elements.NewGeminiElement()
 		audioResampleElement := elements.NewAudioResampleElement(48000, 16000, 1, 1)
 
@@ -39,14 +39,14 @@ func (c *connectionEventHandler) OnConnectionStateChange(state webrtc.PeerConnec
 		elements := []pipeline.Element{
 			audioResampleElement,
 			geminiElement,
-			playoutSinkElement,
+			audioPacerSinkElement,
 		}
 
 		pipeline := pipeline.NewPipeline("rtc_connection")
 		pipeline.AddElements(elements)
 
 		pipeline.Link(audioResampleElement, geminiElement)
-		pipeline.Link(geminiElement, playoutSinkElement)
+		pipeline.Link(geminiElement, audioPacerSinkElement)
 
 		c.pipeline = pipeline
 

--- a/examples/grpc-assis/README.md
+++ b/examples/grpc-assis/README.md
@@ -9,7 +9,7 @@ Client (Go gRPC Client)
     ↓ gRPC Bidirectional Streaming
 Server (GRPCServer)
     ↓ Pipeline
-AudioResampleElement → GeminiElement → PlayoutSinkElement
+AudioResampleElement → GeminiElement → AudioPacerSinkElement
     ↓
 Google Gemini API
 ```
@@ -96,7 +96,7 @@ Run:
 1. **Server**:
    - Starts a gRPC server on port 50051
    - Waits for client connections
-   - On connection, creates a pipeline: Resample → Gemini → Playout
+   - On connection, creates a pipeline: Resample → Gemini → AudioPacer
    - Processes incoming audio/text and sends responses back
 
 2. **Client**:
@@ -115,7 +115,7 @@ Run:
    → StreamMessage(type=AUDIO, AudioFrame{48kHz, mono, PCM})
    → Server: AudioResampleElement (48kHz → 16kHz)
    → Server: GeminiElement (AI processing)
-   → Server: PlayoutSinkElement
+   → Server: AudioPacerSinkElement
    → StreamMessage response back to client
 
 3. Client sends text message
@@ -153,18 +153,18 @@ Edit `server.go`, modify the `OnConnectionStateChange` handler:
 vadElement := elements.NewVADElement()
 audioResampleElement := elements.NewAudioResampleElement(48000, 16000, 1, 1)
 geminiElement := elements.NewGeminiElement()
-playoutSinkElement := elements.NewPlayoutSinkElement()
+audioPacerSinkElement := elements.NewAudioPacerSinkElement()
 
 elements := []pipeline.Element{
     audioResampleElement,
     vadElement,           // Add VAD
     geminiElement,
-    playoutSinkElement,
+    audioPacerSinkElement,
 }
 
 pipeline.Link(audioResampleElement, vadElement)
 pipeline.Link(vadElement, geminiElement)
-pipeline.Link(geminiElement, playoutSinkElement)
+pipeline.Link(geminiElement, audioPacerSinkElement)
 ```
 
 ### Change the Server Port

--- a/examples/grpc-assis/server/main.go
+++ b/examples/grpc-assis/server/main.go
@@ -27,7 +27,7 @@ func (c *connectionEventHandler) OnConnectionStateChange(state webrtc.PeerConnec
 
 	if state == webrtc.PeerConnectionStateConnected {
 		// Create pipeline elements
-		playoutSinkElement := elements.NewPlayoutSinkElement()
+		audioPacerSinkElement := elements.NewAudioPacerSinkElement()
 		geminiElement := elements.NewGeminiElement()
 		audioResampleElement := elements.NewAudioResampleElement(48000, 16000, 1, 1)
 
@@ -35,7 +35,7 @@ func (c *connectionEventHandler) OnConnectionStateChange(state webrtc.PeerConnec
 		elements := []pipeline.Element{
 			audioResampleElement,
 			geminiElement,
-			playoutSinkElement,
+			audioPacerSinkElement,
 		}
 
 		pipeline := pipeline.NewPipeline("grpc_connection")
@@ -43,7 +43,7 @@ func (c *connectionEventHandler) OnConnectionStateChange(state webrtc.PeerConnec
 
 		// Link elements
 		pipeline.Link(audioResampleElement, geminiElement)
-		pipeline.Link(geminiElement, playoutSinkElement)
+		pipeline.Link(geminiElement, audioPacerSinkElement)
 
 		c.pipeline = pipeline
 

--- a/examples/local-assis/main.go
+++ b/examples/local-assis/main.go
@@ -54,13 +54,13 @@ func main() {
 
 	p := pipeline.NewPipeline("local-assis")
 
-	playoutSinkElement := elements.NewPlayoutSinkElement()
+	audioPacerSinkElement := elements.NewAudioPacerSinkElement()
 	geminiElement := elements.NewGeminiElement()
 
 	p.AddElement(geminiElement)
-	p.AddElement(playoutSinkElement)
+	p.AddElement(audioPacerSinkElement)
 
-	p.Link(geminiElement, playoutSinkElement)
+	p.Link(geminiElement, audioPacerSinkElement)
 
 	eventHandler.pipeline = p
 
@@ -68,9 +68,9 @@ func main() {
 
 	// 创建音频 dumper
 	var dumper *audio.Dumper
-	if os.Getenv("DUMP_PLAYOUT_OUTPUT") == "true" {
+	if os.Getenv("DUMP_PACER_OUTPUT") == "true" {
 		var err error
-		dumper, err = audio.NewDumper("playout_output", 48000, 1) // 使用48kHz采样率，单声道
+		dumper, err = audio.NewDumper("pacer_output", 48000, 1) // 使用48kHz采样率，单声道
 		if err != nil {
 			log.Printf("create audio dumper error: %v", err)
 		} else {

--- a/examples/openai-tts/main.go
+++ b/examples/openai-tts/main.go
@@ -82,7 +82,7 @@ func main() {
 					audioMsg.AudioData.Channels)
 
 				// Here you could save the audio to a file or send it to another element
-				// For example, you could link it to a PlayoutSinkElement for playback
+				// For example, you could link it to an AudioPacerSinkElement for playback
 			}
 		case <-time.After(10 * time.Second):
 			log.Printf("Timeout waiting for audio output")

--- a/examples/tracing-demo/main.go
+++ b/examples/tracing-demo/main.go
@@ -59,18 +59,18 @@ func runTracedPipeline(ctx context.Context) error {
 	// Create and add elements
 	resampleElement := elements.NewAudioResampleElement(16000, 1)
 	geminiElement := elements.NewGeminiElement()
-	playoutElement := elements.NewPlayoutSinkElement()
+	audioPacerElement := elements.NewAudioPacerSinkElement()
 
 	p.AddElements([]pipeline.Element{
 		resampleElement,
 		geminiElement,
-		playoutElement,
+		audioPacerElement,
 	})
 
 	// Link elements
 	unlink1 := p.Link(resampleElement, geminiElement)
 	defer unlink1()
-	unlink2 := p.Link(geminiElement, playoutElement)
+	unlink2 := p.Link(geminiElement, audioPacerElement)
 	defer unlink2()
 
 	// Start pipeline with tracing

--- a/pkg/audio/audio_pacer.go
+++ b/pkg/audio/audio_pacer.go
@@ -23,22 +23,22 @@ const (
 	BytesPerFrame48kHz   = SamplesPerFrame48kHz * BytesPerSample * Channels
 )
 
-// PlayoutBuffer 实现固定长度的音频输出，支持24kHz输入重采样到48kHz输出
-type PlayoutBuffer struct {
+// AudioPacer 控制音频输出节奏，实现固定20ms间隔的音频帧输出，支持24kHz输入重采样到48kHz输出
+type AudioPacer struct {
 	buffer       []byte
 	mu           sync.Mutex
 	resampler    *Resample
 	accumulating bool // 是否正在积累数据
 }
 
-// NewPlayoutBuffer 创建新的 PlayoutBuffer
-func NewPlayoutBuffer() (*PlayoutBuffer, error) {
+// NewAudioPacer 创建新的 AudioPacer
+func NewAudioPacer() (*AudioPacer, error) {
 	resampler, err := NewResample(InputSampleRate, OutputSampleRate, astiav.ChannelLayoutMono, astiav.ChannelLayoutMono)
 	if err != nil {
 		return nil, err
 	}
 
-	return &PlayoutBuffer{
+	return &AudioPacer{
 		buffer:       make([]byte, 0, BytesPerFrame48kHz*100), // 预分配2秒的容量
 		resampler:    resampler,
 		accumulating: false,
@@ -46,53 +46,53 @@ func NewPlayoutBuffer() (*PlayoutBuffer, error) {
 }
 
 // Write 写入24kHz采样率的音频数据
-func (pb *PlayoutBuffer) Write(data []byte) error {
+func (ap *AudioPacer) Write(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
 
 	// 重采样到48kHz
-	resampledData, err := pb.resampler.Resample(data)
+	resampledData, err := ap.resampler.Resample(data)
 	if err != nil {
 		return err
 	}
 
-	pb.mu.Lock()
-	defer pb.mu.Unlock()
-	pb.buffer = append(pb.buffer, resampledData...)
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	ap.buffer = append(ap.buffer, resampledData...)
 	return nil
 }
 
 // ReadFrame 读取固定20ms的48kHz音频帧
 // 如果没有足够的数据，将返回静音数据
-func (pb *PlayoutBuffer) ReadFrame() []byte {
-	pb.mu.Lock()
-	defer pb.mu.Unlock()
+func (ap *AudioPacer) ReadFrame() []byte {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
 
 	// 准备输出缓冲区
 	frame := make([]byte, BytesPerFrame48kHz)
 
 	// 如果正在积累数据且缓冲区小于100ms，返回静音
-	if pb.accumulating && len(pb.buffer) < BytesPerFrame48kHz*10 { // 10帧 = 200ms
+	if ap.accumulating && len(ap.buffer) < BytesPerFrame48kHz*10 { // 10帧 = 200ms
 		return frame
 	}
 
 	// 如果有足够数据，关闭积累状态
-	if pb.accumulating && len(pb.buffer) >= BytesPerFrame48kHz*10 {
-		pb.accumulating = false
-		log.Printf("accumulated enough data (%d bytes), starting playback", len(pb.buffer))
+	if ap.accumulating && len(ap.buffer) >= BytesPerFrame48kHz*10 {
+		ap.accumulating = false
+		log.Printf("accumulated enough data (%d bytes), starting playback", len(ap.buffer))
 	}
 
-	if len(pb.buffer) >= BytesPerFrame48kHz {
+	if len(ap.buffer) >= BytesPerFrame48kHz {
 		// 有足够的数据，复制一帧
-		copy(frame, pb.buffer[:BytesPerFrame48kHz])
+		copy(frame, ap.buffer[:BytesPerFrame48kHz])
 		// 移除已读取的数据
-		pb.buffer = pb.buffer[BytesPerFrame48kHz:]
-	} else if len(pb.buffer) > 0 {
+		ap.buffer = ap.buffer[BytesPerFrame48kHz:]
+	} else if len(ap.buffer) > 0 {
 		// 有部分数据，复制可用部分，其余填充静音
-		copy(frame, pb.buffer)
+		copy(frame, ap.buffer)
 		// 清空缓冲区
-		pb.buffer = pb.buffer[:0]
+		ap.buffer = ap.buffer[:0]
 	}
 	// 如果没有数据，frame 保持为零值（静音）
 
@@ -100,28 +100,28 @@ func (pb *PlayoutBuffer) ReadFrame() []byte {
 }
 
 // Clear 清空缓冲区并开始积累新数据
-func (pb *PlayoutBuffer) Clear() {
-	pb.mu.Lock()
-	defer pb.mu.Unlock()
-	log.Printf("clear buffer: %d, starting accumulation", len(pb.buffer))
-	pb.buffer = pb.buffer[:0]
-	pb.accumulating = true
+func (ap *AudioPacer) Clear() {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	log.Printf("clear buffer: %d, starting accumulation", len(ap.buffer))
+	ap.buffer = ap.buffer[:0]
+	ap.accumulating = true
 }
 
 // Available 返回当前可用的音频数据长度（字节）
-func (pb *PlayoutBuffer) Available() int {
-	pb.mu.Lock()
-	defer pb.mu.Unlock()
-	return len(pb.buffer)
+func (ap *AudioPacer) Available() int {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	return len(ap.buffer)
 }
 
 // Close 释放资源
-func (pb *PlayoutBuffer) Close() {
-	pb.mu.Lock()
-	defer pb.mu.Unlock()
-	if pb.resampler != nil {
-		pb.resampler.Free()
-		pb.resampler = nil
+func (ap *AudioPacer) Close() {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	if ap.resampler != nil {
+		ap.resampler.Free()
+		ap.resampler = nil
 	}
-	pb.buffer = nil
+	ap.buffer = nil
 }

--- a/pkg/audio/audio_pacer_test.go
+++ b/pkg/audio/audio_pacer_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlayoutBuffer(t *testing.T) {
-	pb, err := NewPlayoutBuffer()
+func TestAudioPacer(t *testing.T) {
+	ap, err := NewAudioPacer()
 	require.NoError(t, err)
-	defer pb.Close()
+	defer ap.Close()
 
 	t.Run("Empty buffer returns silence", func(t *testing.T) {
-		frame := pb.ReadFrame()
+		frame := ap.ReadFrame()
 		assert.Equal(t, BytesPerFrame48kHz, len(frame))
 		// 验证是否为静音（全0）
 		for _, b := range frame {
@@ -28,11 +28,11 @@ func TestPlayoutBuffer(t *testing.T) {
 			testData[i] = byte(i % 256)
 		}
 
-		err := pb.Write(testData)
+		err := ap.Write(testData)
 		require.NoError(t, err)
 
 		// 读取重采样后的48kHz数据
-		frame := pb.ReadFrame()
+		frame := ap.ReadFrame()
 		assert.Equal(t, BytesPerFrame48kHz, len(frame))
 		// 由于经过重采样，我们不能直接比较数据内容
 		// 但可以验证不是静音数据
@@ -54,10 +54,10 @@ func TestPlayoutBuffer(t *testing.T) {
 			testData[i] = byte(i % 256)
 		}
 
-		err := pb.Write(testData)
+		err := ap.Write(testData)
 		require.NoError(t, err)
 
-		frame := pb.ReadFrame()
+		frame := ap.ReadFrame()
 		assert.Equal(t, BytesPerFrame48kHz, len(frame))
 		// 验证输出不全是静音
 		hasNonZero := false
@@ -77,12 +77,12 @@ func TestPlayoutBuffer(t *testing.T) {
 			testData[i] = byte(i % 256)
 		}
 
-		err := pb.Write(testData)
+		err := ap.Write(testData)
 		require.NoError(t, err)
 
 		// 读取三帧48kHz数据
 		for i := 0; i < 3; i++ {
-			frame := pb.ReadFrame()
+			frame := ap.ReadFrame()
 			assert.Equal(t, BytesPerFrame48kHz, len(frame))
 			// 验证不是静音
 			hasNonZero := false
@@ -96,7 +96,7 @@ func TestPlayoutBuffer(t *testing.T) {
 		}
 
 		// 第四帧应该是静音
-		frame := pb.ReadFrame()
+		frame := ap.ReadFrame()
 		for _, b := range frame {
 			assert.Equal(t, byte(0), b)
 		}
@@ -108,15 +108,15 @@ func TestPlayoutBuffer(t *testing.T) {
 		for i := range testData {
 			testData[i] = byte(i % 256)
 		}
-		err := pb.Write(testData)
+		err := ap.Write(testData)
 		require.NoError(t, err)
 
 		// 清空缓冲区
-		pb.Clear()
-		assert.Equal(t, 0, pb.Available())
+		ap.Clear()
+		assert.Equal(t, 0, ap.Available())
 
 		// 验证读取返回静音
-		frame := pb.ReadFrame()
+		frame := ap.ReadFrame()
 		assert.Equal(t, BytesPerFrame48kHz, len(frame))
 		for _, b := range frame {
 			assert.Equal(t, byte(0), b)
@@ -124,7 +124,7 @@ func TestPlayoutBuffer(t *testing.T) {
 	})
 
 	t.Run("Write empty data", func(t *testing.T) {
-		err := pb.Write([]byte{})
+		err := ap.Write([]byte{})
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Renamed the playout module to AudioPacer to better reflect its core functionality: controlling audio output timing with fixed 20ms frame intervals.

Changes:
- Renamed files:
  * pkg/audio/playout.go → pkg/audio/audio_pacer.go
  * pkg/audio/playout_test.go → pkg/audio/audio_pacer_test.go
  * pkg/elements/playout_sink_element.go → pkg/elements/audio_pacer_sink_element.go

- Updated type names:
  * PlayoutBuffer → AudioPacer
  * PlayoutSinkElement → AudioPacerSinkElement
  * NewPlayoutBuffer() → NewAudioPacer()
  * NewPlayoutSinkElement() → NewAudioPacerSinkElement()

- Updated environment variable:
  * DUMP_PLAYOUT_OUTPUT → DUMP_PACER_OUTPUT

- Updated all documentation and examples to reflect the new naming

The name "AudioPacer" more accurately describes the module's purpose: pacing audio output at precise 20ms intervals for real-time playback.