### PR TITLE
fix: update FFmpeg to 8.0 for go-astiav v0.30.0 compatibility

### DIFF
--- a/scripts/setup-ffmpeg.sh
+++ b/scripts/setup-ffmpeg.sh
@@ -11,10 +11,11 @@
 
 set -e
 
-FFMPEG_VERSION="7.0.1"
+FFMPEG_VERSION="8.0"
 FFMPEG_DIR="${FFMPEG_DIR:-$HOME/ffmpeg}"
-FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-07-31-12-50/ffmpeg-n7.0.1-linux64-gpl-shared-7.0.tar.xz"
-FFMPEG_MACOS_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-07-31-12-50/ffmpeg-n7.0.1-macos64-gpl-shared-7.0.tar.xz"
+# go-astiav v0.30.0 requires FFmpeg n8.0
+FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.0-latest-linux64-gpl-shared-8.0.tar.xz"
+FFMPEG_MACOS_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.0-latest-macos64-gpl-shared-8.0.tar.xz"
 
 print_env() {
     echo "export PKG_CONFIG_PATH=\"$FFMPEG_DIR/lib/pkgconfig:\$PKG_CONFIG_PATH\""
@@ -92,7 +93,7 @@ install_linux() {
     wget -q --show-progress "$FFMPEG_URL" -O ffmpeg.tar.xz
     echo "Extracting..."
     tar xf ffmpeg.tar.xz
-    mv ffmpeg-n${FFMPEG_VERSION}-linux64-gpl-shared-7.0 "$FFMPEG_DIR"
+    mv ffmpeg-n${FFMPEG_VERSION}-latest-linux64-gpl-shared-8.0 "$FFMPEG_DIR"
     cd -
     rm -rf "$TMPDIR"
 


### PR DESCRIPTION
The setup-ffmpeg.sh script was using FFmpeg 7.0.1, but go-astiav v0.30.0 requires FFmpeg n8.0. This caused build errors:
- could not determine what C.av_buffersink_get_color_range refers to
- could not determine what C.av_buffersink_get_colorspace refers to

Changes:
- Update FFMPEG_VERSION from 7.0.1 to 8.0
- Update download URLs to use latest release tag
- Update extract directory pattern to match new naming

Fixes #64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a local setup script’s FFmpeg version/URLs and the expected extracted directory name; main risk is breakage if the upstream “latest” asset naming changes.
> 
> **Overview**
> Updates `scripts/setup-ffmpeg.sh` to install **FFmpeg 8.0** (required for `go-astiav` v0.30.0) instead of 7.0.1.
> 
> Switches Linux/macOS download URLs to the `latest` release assets for `n8.0`, and updates the post-extract `mv` path to match the new archive directory naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 565ff9b5b5f17f15c68fce6636cf9f2a0e8e00b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->